### PR TITLE
Corrected unneeded increment of MessageOffset Counter, which caused to message update skip.

### DIFF
--- a/ICQ.Bot/ICQ.Bot.Net.csproj
+++ b/ICQ.Bot/ICQ.Bot.Net.csproj
@@ -17,7 +17,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="rem copy $(OutDir)$(TargetFileName) D:\Projects\TOImageProcessor\branches\MailAgentSupport\TOImageProcessor\Lib\$(TargetFileName) /V /Y" />
+  </Target>
 
 </Project>

--- a/ICQ.Bot/ICQBotClient.cs
+++ b/ICQ.Bot/ICQBotClient.cs
@@ -10,6 +10,7 @@ using ICQ.Bot.Types.ReplyMarkups;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -209,8 +210,8 @@ namespace ICQ.Bot
                         foreach (var update in updates.Events)
                         {
                             OnUpdateReceived(new UpdateEventArgs(update));
-                            MessageOffset = update.EventId + 1;
                         }
+                        MessageOffset = updates.Events.LastOrDefault()?.EventId ?? MessageOffset;
                     }
                 }
                 catch
@@ -327,7 +328,7 @@ namespace ICQ.Bot
                 string queryString;
                 if (httpContent != null)
                 {
-                    string prefix = await httpContent.ReadAsStringAsync();
+                    string prefix = await httpContent.ReadAsStringAsync().ConfigureAwait(false);
                     prefix = HttpUtility.UrlDecode(prefix);
                     queryString = string.Format("{0}&token={1}", prefix, _token);
                 }
@@ -392,7 +393,6 @@ namespace ICQ.Bot
                 string text = string.Format("response failed to be parsed");
                 throw new ApiRequestException(text);
             }
-
 
             return apiResponse;
         }

--- a/ICQ.Bot/Properties/launchSettings.json
+++ b/ICQ.Bot/Properties/launchSettings.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "ICQ.Bot.Net": {
+      "commandName": "Project"
+    }
+  }
+}

--- a/ICQ.Bot/Types/ChatId.cs
+++ b/ICQ.Bot/Types/ChatId.cs
@@ -15,7 +15,7 @@ namespace ICQ.Bot.Types
             Identifier = identifier;
         }
 
-        public ChatId(int chatId)
+        public ChatId(int chatId)   
         {
             Identifier = chatId;
         }


### PR DESCRIPTION
Исправил избыточное наращивание счётчика сообщений, что противоречило API Mail.ru, где lastEventId - Id последнего известного события.

Итог: сообщения больше не пропускаются вне зависимости от частоты их поступления.
------------------------------------------------------------------------- Translation ---------------------
Corrected unneeded increment of MessageOffset Counter, which caused to message update skip.
Now all messages will be received with any frequency.
See https://agent.mail.ru/botapi/?lang=en#/events/get_events_get