### PR TITLE
1.4.7 alpha

### DIFF
--- a/ICQ.Bot/ICQ.Bot.Net.csproj
+++ b/ICQ.Bot/ICQ.Bot.Net.csproj
@@ -17,7 +17,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="rem copy $(OutDir)$(TargetFileName) D:\Projects\TOImageProcessor\branches\MailAgentSupport\TOImageProcessor\Lib\$(TargetFileName) /V /Y" />
+  </Target>
 
 </Project>

--- a/ICQ.Bot/ICQBotClient.cs
+++ b/ICQ.Bot/ICQBotClient.cs
@@ -43,6 +43,9 @@ namespace ICQ.Bot
         public bool IsReceiving { get; set; }
 
         private CancellationTokenSource _receivingCancellationTokenSource;
+        /// <summary>
+        /// Id of the last known (processed) event.
+        /// </summary>
         public int MessageOffset { get; set; }
 
         public ICQBotClient(string token, HttpClient httpClient = null)
@@ -210,8 +213,9 @@ namespace ICQ.Bot
                         foreach (var update in updates.Events)
                         {
                             OnUpdateReceived(new UpdateEventArgs(update));
+                            MessageOffset = update.EventId;
                         }
-                        MessageOffset = updates.Events.LastOrDefault()?.EventId ?? MessageOffset;
+                        //MessageOffset = updates.Events.LastOrDefault()?.EventId ?? MessageOffset;
                     }
                 }
                 catch

--- a/ICQ.Bot/ICQBotClient.cs
+++ b/ICQ.Bot/ICQBotClient.cs
@@ -1,4 +1,12 @@
-﻿using ICQ.Bot.Args;
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
+
+using ICQ.Bot.Args;
 using ICQ.Bot.Converters;
 using ICQ.Bot.Exceptions;
 using ICQ.Bot.Requests;
@@ -7,15 +15,9 @@ using ICQ.Bot.Types;
 using ICQ.Bot.Types.Enums;
 using ICQ.Bot.Types.InputFiles;
 using ICQ.Bot.Types.ReplyMarkups;
+
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Web;
+
 
 namespace ICQ.Bot
 {

--- a/ICQ.Bot/ICQBotClient.cs
+++ b/ICQ.Bot/ICQBotClient.cs
@@ -10,6 +10,7 @@ using ICQ.Bot.Types.ReplyMarkups;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -209,8 +210,8 @@ namespace ICQ.Bot
                         foreach (var update in updates.Events)
                         {
                             OnUpdateReceived(new UpdateEventArgs(update));
-                            MessageOffset = update.EventId + 1;
                         }
+                        MessageOffset = updates.Events.LastOrDefault()?.EventId ?? MessageOffset;
                     }
                 }
                 catch
@@ -327,7 +328,7 @@ namespace ICQ.Bot
                 string queryString;
                 if (httpContent != null)
                 {
-                    string prefix = await httpContent.ReadAsStringAsync();
+                    string prefix = await httpContent.ReadAsStringAsync().ConfigureAwait(false);
                     prefix = HttpUtility.UrlDecode(prefix);
                     queryString = string.Format("{0}&token={1}", prefix, _token);
                 }
@@ -392,7 +393,6 @@ namespace ICQ.Bot
                 string text = string.Format("response failed to be parsed");
                 throw new ApiRequestException(text);
             }
-
 
             return apiResponse;
         }

--- a/ICQ.Bot/Properties/launchSettings.json
+++ b/ICQ.Bot/Properties/launchSettings.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "ICQ.Bot.Net": {
+      "commandName": "Project"
+    }
+  }
+}

--- a/ICQ.Bot/Types/ChatId.cs
+++ b/ICQ.Bot/Types/ChatId.cs
@@ -15,7 +15,7 @@ namespace ICQ.Bot.Types
             Identifier = identifier;
         }
 
-        public ChatId(int chatId)
+        public ChatId(int chatId)   
         {
             Identifier = chatId;
         }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![package](https://img.shields.io/badge/ICQ.Bot-v1.4.6-blue)](https://www.nuget.org/packages/ICQ.Bot)
+[![package](https://img.shields.io/badge/ICQ.Bot-v1.4.7_alpha-blue)](https://www.nuget.org/packages/ICQ.Bot)
 [![icq chat](https://img.shields.io/badge/Community-Chat-yellow)](https://icq.im/bots_dotnet)
 [![license](https://img.shields.io/badge/license-MIT-green)](https://github.com/idan-rubin/icq.bot.net/blob/master/LICENSE)
 [![Bot API Version](https://img.shields.io/badge/Bot%20API%20Version-20.03.2020-ff69b4)](https://agent.mail.ru/botapi/?lang=en#/self/get_self_get)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 [![package](https://img.shields.io/badge/ICQ.Bot-v1.4.6-blue)](https://www.nuget.org/packages/ICQ.Bot)
-[![icq chat](https://img.shields.io/badge/Community-Chat-blue)](https://icq.im/bots_dotnet)
-[![license](https://img.shields.io/badge/license-MIT-brightgreen)](https://github.com/idan-rubin/icq.bot.net/blob/master/LICENSE)
+[![icq chat](https://img.shields.io/badge/Community-Chat-yellow)](https://icq.im/bots_dotnet)
+[![license](https://img.shields.io/badge/license-MIT-green)](https://github.com/idan-rubin/icq.bot.net/blob/master/LICENSE)
+[![Bot API Version](https://img.shields.io/badge/Bot%20API%20Version-20.03.2020-ff69b4)](https://agent.mail.ru/botapi/?lang=en#/self/get_self_get)
 
 # icq.bot.net
 
-HTTP-Based C# implementation for ICQ Bot APIs (also known as Mail.ru Agent bot API / VK Teams bot API).
+HTTP-Based C# implementation for [ICQ Bot APIs](https://icq.com/botapi/) (also known as [Mail.ru Agent bot API](https://agent.mail.ru/botapi/?lang=ru) / [VK Teams](https://help.mail.ru/biz/myteam) bot API).
 
 No Microsoft proprietary mambo jumbo needed! Built on the goodness of .Net Standard 2.0 and Newtonsoft.Json
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 # icq.bot.net
 
-HTTP-Based C# implementation for ICQ Bot APIs.
+HTTP-Based C# implementation for ICQ Bot APIs (also known as Mail.ru Agent bot API / VK Teams bot API).
 
-No Microsoft proprietary mambo jumbo needed! Built on the goodness of .Net Standard 2.0 and Json.Net
+No Microsoft proprietary mambo jumbo needed! Built on the goodness of .Net Standard 2.0 and Newtonsoft.Json
 
 ## What's in it for me?
 With this package you can:


### PR DESCRIPTION
Исправил избыточное наращивание счётчика сообщений, что противоречило (https://github.com/idan-rubin/icq.bot.net/commit/b295a8f91648d2ba4373ba42832015e81dec660b) 

API Mail.ru, где lastEventId - Id последнего известного события.

Итог: сообщения больше не пропускаются вне зависимости от частоты их поступления.
-------------------------------------------------------------------------
Corrected unneeded increment of MessageOffset Counter, which caused to message update skip.
Now all messages will be received with any frequency.